### PR TITLE
fixed >100% scale bug when milliseconds matters

### DIFF
--- a/ffmprog
+++ b/ffmprog
@@ -43,11 +43,7 @@ get_infos(){
 		die "1" "An Error Occured"
 	fi
 	# Time
-	hrs="${vid_dur%%:*}"
-	mins="$(printf '%s' "${vid_dur}" | cut -d':' -f2)"
-	secs="${vid_dur##*:}" secs="${secs%%.*}" secs="${secs##0}"
-	vid_time="$((hrs * 3600 + mins * 60 + secs))"
-	total_frames="$(printf '%s\n' "${vid_time} * ${vid_fps}" | bc)" total_frames="${total_frames%%.*}"
+	total_frames="$(echo "${vid_dur}" | sed -E "s/^([0-9]+):([0-9]{2}):([0-9]{2}\.[0-9]+)$/\((\1 * 60 + \2) * 60 + \3) * ${vid_fps}/" | bc | awk -F . '{print $1}')"
 }
 
 run_background(){


### PR DESCRIPTION
I had a bug with a video which was 2.8 seconds long. The old calculation ignored 800ms, so it was `25fps * 2s = 50frames` instead of `25fps * 2.8s = 70frames`. When the encoding process reached frame numbers above 50, the layout crashed - resulting in a new line every encoding step.

This commit fixes the problem with a `sed` RegEx-solution.